### PR TITLE
Edit the station schemato reflect the new station ID keys

### DIFF
--- a/database/models/station.js
+++ b/database/models/station.js
@@ -3,7 +3,7 @@ const Schema = mongoose.Schema;
 
 const stationSchema = new Schema({
     _station_key: {
-        type: Number, 
+        type: string, 
         required: true
     },
     name:  {
@@ -18,7 +18,7 @@ const stationSchema = new Schema({
         type: String, 
         required: true
     },
-    amenitites:  {
+    amenities:  {
         type: Array, 
         required: true
     },

--- a/index.js
+++ b/index.js
@@ -28,9 +28,10 @@ app.get("/arrivals", (req, res) => {
 });
 
 const PORT = process.env.PORT || 3000;
-app.listen(PORT, () => console.log(`listening on ${PORT}`));
 
-connectDB();
+connectDB().then(() => {
+  app.listen(PORT, () => console.log(`listening on ${PORT}`));
+})
 // mongo DB api
 
 app.get('/api/get/all/stations', (req, res) => {


### PR DESCRIPTION
current station schema was resulting in the below API response:
{"amenities":[],
"_id":"654c3231a9ea3de300a8eaf4",
"name":"AIRPORT STATION",
"longitude":"-84.448631",
"latitude":"33.639809",
"amenities":[1,2,3],
"_schedule_key":2,
"contactnumber":"404-848-5000",
"description":"Airport Station is the final station on the south end of the Red and Gold lines.",
"busroutes":[]}

Edited to ensure station key is accurate and renamed amenities to prevent duplicate amenities from displaying in API.